### PR TITLE
feat: add gpt-image-1-mini support, prompt augmentation, and revised-prompt UI

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -17,13 +17,21 @@ WORKDIR /usr/src/app
 COPY package*.json ./
 
 # Install dependencies
-RUN npm ci --only=production
+# Using `npm install --omit=dev` rather than `npm ci` because the committed
+# lockfile drifts from package.json (vitest@^3 was added without a lockfile
+# refresh). Switch back to `npm ci` once `npm install` has been run on a
+# clean checkout and the updated server/package-lock.json is committed.
+RUN npm install --omit=dev
 
 # Copy app source
 COPY . .
 
 # Create non-root user
 RUN addgroup -S appgroup && adduser -S appuser -G appgroup
+# Pre-create the local data dir so the named volume mounted at /usr/src/app/data
+# inherits appuser ownership on first creation (otherwise the volume is
+# root-owned and the non-root process can't mkdir inside it).
+RUN mkdir -p /usr/src/app/data/storage /usr/src/app/logs
 RUN chown -R appuser:appgroup /usr/src/app
 USER appuser
 

--- a/server/routes/images.js
+++ b/server/routes/images.js
@@ -28,7 +28,7 @@ router.get('/models', (req, res) => {
   res.json({
     success: true,
     models: Object.entries(IMAGE_MODELS).map(([id, config]) => ({ id, ...config })),
-    default: 'gpt-image-1',
+    default: 'dall-e-3',
   })
 })
 

--- a/server/routes/images.js
+++ b/server/routes/images.js
@@ -53,7 +53,7 @@ router.get('/platforms', (req, res) => {
 // Generate images from text prompt
 router.post('/generate', authMiddleware, async (req, res) => {
   try {
-    const { prompt, presets, model, quality, style } = req.body
+    const { prompt, presets, model, quality, style, augment } = req.body
 
     // Validation
     if (!prompt || typeof prompt !== 'string' || prompt.trim().length === 0) {
@@ -99,6 +99,7 @@ router.post('/generate', authMiddleware, async (req, res) => {
     if (model) genOptions.model = model
     if (quality) genOptions.quality = quality
     if (style) genOptions.style = style
+    if (augment === false) genOptions.augment = false
     const result = await generateImagesFromPrompt(prompt, presets, userApiKey, genOptions)
 
     res.json({

--- a/server/services/imageService.js
+++ b/server/services/imageService.js
@@ -31,12 +31,16 @@ export const PLATFORM_PRESETS = {
 
 // Supported image generation models
 export const IMAGE_MODELS = {
-  'gpt-image-1': { name: 'GPT Image 1', sizes: ['1024x1024', '1024x1536', '1536x1024', 'auto'], qualities: ['low', 'medium', 'high', 'auto'], outputFormats: ['png', 'webp', 'jpeg'] },
+  'gpt-image-1': { name: 'GPT Image 1', sizes: ['1024x1024', '1024x1536', '1536x1024', 'auto'], qualities: ['low', 'medium', 'high', 'auto'], outputFormats: ['png', 'webp', 'jpeg'], backgrounds: ['transparent', 'opaque', 'auto'] },
+  'gpt-image-1-mini': { name: 'GPT Image 1 Mini', sizes: ['1024x1024', '1024x1536', '1536x1024', 'auto'], qualities: ['low', 'medium', 'high', 'auto'], outputFormats: ['png', 'webp', 'jpeg'], backgrounds: ['transparent', 'opaque', 'auto'] },
   'dall-e-3': { name: 'DALL-E 3', sizes: ['1024x1024', '1024x1792', '1792x1024'], qualities: ['standard', 'hd'], styles: ['vivid', 'natural'] },
   'dall-e-2': { name: 'DALL-E 2', sizes: ['256x256', '512x512', '1024x1024'], qualities: ['standard'] },
 };
 
-const DEFAULT_MODEL = 'gpt-image-1';
+// GPT image family shares the same param contract (b64_json output, same sizes/qualities/formats)
+const GPT_IMAGE_MODELS = new Set(['gpt-image-1', 'gpt-image-1-mini']);
+
+const DEFAULT_MODEL = 'dall-e-3';
 
 /**
  * Generate image using OpenAI image generation API
@@ -53,9 +57,11 @@ export async function generateWithDallE(prompt, options = {}, apiKey = null) {
       n: 1,
     };
 
-    if (model === 'gpt-image-1') {
+    if (GPT_IMAGE_MODELS.has(model)) {
       params.size = options.size || 'auto';
       params.quality = options.quality || 'auto';
+      if (options.outputFormat) params.output_format = options.outputFormat;
+      if (options.background) params.background = options.background;
     } else {
       params.size = options.size || '1024x1024';
       params.quality = options.quality || 'standard';

--- a/server/services/imageService.js
+++ b/server/services/imageService.js
@@ -42,6 +42,18 @@ const GPT_IMAGE_MODELS = new Set(['gpt-image-1', 'gpt-image-1-mini']);
 
 const DEFAULT_MODEL = 'dall-e-3';
 
+// Lightweight prompt augmentation — nudges the model toward usable
+// social-asset output (centered, well-lit, crops cleanly to multiple
+// aspect ratios) without rewriting the user's intent. Opt-out via
+// the `augment: false` option.
+const AUGMENT_SUFFIX = 'Professional, high-quality composition. Centered subject with breathing room around the edges so the image crops cleanly to square, portrait, and landscape ratios. Sharp focus, balanced lighting.';
+
+export function augmentPrompt(prompt) {
+  const trimmed = (prompt || '').trim();
+  if (!trimmed) return trimmed;
+  return `${trimmed} — ${AUGMENT_SUFFIX}`;
+}
+
 /**
  * Generate image using OpenAI image generation API
  */
@@ -212,8 +224,13 @@ export async function generateImagesFromPrompt(prompt, presetIds, apiKey = null,
     throw new Error('OpenAI API key not configured');
   }
 
+  // Augmentation defaults on; caller can opt out with { augment: false }
+  const shouldAugment = options.augment !== false;
+  const finalPrompt = shouldAugment ? augmentPrompt(prompt) : prompt;
+  const wasAugmented = shouldAugment && finalPrompt !== prompt;
+
   // Generate the base image
-  const generated = await generateWithDallE(prompt, options, apiKey);
+  const generated = await generateWithDallE(finalPrompt, options, apiKey);
 
   // Get image buffer (either from URL download or direct base64)
   const imageBuffer = generated.b64Buffer || await downloadImage(generated.url);
@@ -238,6 +255,7 @@ export async function generateImagesFromPrompt(prompt, presetIds, apiKey = null,
         size: resized.size,
         image: `data:image/png;base64,${base64}`,
         revisedPrompt: generated.revisedPrompt,
+        augmentedPrompt: wasAugmented ? finalPrompt : undefined,
       };
     })
   );
@@ -246,6 +264,7 @@ export async function generateImagesFromPrompt(prompt, presetIds, apiKey = null,
 }
 
 export default {
+  augmentPrompt,
   generateWithDallE,
   downloadImage,
   resizeImage,

--- a/src/components/ResultsGrid.css
+++ b/src/components/ResultsGrid.css
@@ -19,6 +19,46 @@
   font-style: italic;
   margin: 0;
 }
+.rg-prompt-toggle {
+  margin-top: 0.4rem;
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: 0.75rem;
+  color: var(--accent);
+  cursor: pointer;
+  font-weight: 600;
+}
+.rg-prompt-toggle:hover { text-decoration: underline; }
+.rg-prompt-details {
+  margin-top: 0.6rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-width: 720px;
+}
+.rg-prompt-block {
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.55rem 0.7rem;
+}
+.rg-prompt-label {
+  display: block;
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-dim);
+  margin-bottom: 0.25rem;
+}
+.rg-prompt-text {
+  font-size: 0.78rem;
+  color: var(--text-primary);
+  margin: 0;
+  line-height: 1.45;
+  white-space: pre-wrap;
+}
 .rg-dl-all {
   font-size: 0.8rem;
   padding: 0.4rem 0.85rem;

--- a/src/components/ResultsGrid.jsx
+++ b/src/components/ResultsGrid.jsx
@@ -6,7 +6,13 @@ import './ResultsGrid.css'
 function ResultsGrid({ results, prompt }) {
   const [preview, setPreview] = useState(null)
   const [zipping, setZipping] = useState(false)
+  const [showPromptDetails, setShowPromptDetails] = useState(false)
   const toast = useToast()
+
+  // Same per-image; pull from the first result.
+  const augmentedPrompt = results[0]?.augmentedPrompt
+  const revisedPrompt = results[0]?.revisedPrompt
+  const hasPromptDetails = Boolean(augmentedPrompt || revisedPrompt)
 
   const src = (img) => img.image || img.url
   const name = (img) => img.platformName || img.preset?.name || img.platform
@@ -69,6 +75,31 @@ function ResultsGrid({ results, prompt }) {
         <div>
           <h2 className="rg-title">Generated Images</h2>
           <p className="rg-prompt">"{prompt}"</p>
+          {hasPromptDetails && (
+            <button
+              type="button"
+              className="rg-prompt-toggle"
+              onClick={() => setShowPromptDetails(v => !v)}
+            >
+              {showPromptDetails ? 'Hide' : 'Show'} prompt details
+            </button>
+          )}
+          {showPromptDetails && (
+            <div className="rg-prompt-details">
+              {augmentedPrompt && (
+                <div className="rg-prompt-block">
+                  <span className="rg-prompt-label">Sent to model</span>
+                  <p className="rg-prompt-text">{augmentedPrompt}</p>
+                </div>
+              )}
+              {revisedPrompt && (
+                <div className="rg-prompt-block">
+                  <span className="rg-prompt-label">Model's revised prompt</span>
+                  <p className="rg-prompt-text">{revisedPrompt}</p>
+                </div>
+              )}
+            </div>
+          )}
         </div>
         <button className="rg-dl-all" onClick={downloadAllZip} disabled={zipping}>
           {zipping ? (

--- a/src/pages/Home.css
+++ b/src/pages/Home.css
@@ -170,6 +170,26 @@
 .prompt-field:disabled { opacity: 0.5; }
 .prompt-field::placeholder { color: var(--text-dimmer); }
 
+.model-section { margin-bottom: 1rem; }
+.model-picker {
+  width: 100%;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.65rem 0.85rem;
+  color: var(--text-primary);
+  font-size: 0.9rem;
+  font-family: inherit;
+  cursor: pointer;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+.model-picker:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-bg);
+}
+.model-picker:disabled { opacity: 0.5; cursor: not-allowed; }
+
 .prompt-meta {
   display: flex;
   justify-content: space-between;

--- a/src/pages/Home.css
+++ b/src/pages/Home.css
@@ -190,6 +190,32 @@
 }
 .model-picker:disabled { opacity: 0.5; cursor: not-allowed; }
 
+.augment-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  margin-top: 0.55rem;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  cursor: pointer;
+  user-select: none;
+}
+.augment-toggle input[type="checkbox"] { cursor: pointer; }
+.augment-toggle input[type="checkbox"]:disabled { cursor: not-allowed; }
+.augment-hint {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--bg-input);
+  border: 1px solid var(--border);
+  font-size: 0.65rem;
+  color: var(--text-dim);
+  cursor: help;
+}
+
 .prompt-meta {
   display: flex;
   justify-content: space-between;

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -4,7 +4,7 @@ import { useAuth } from '../contexts/AuthContext'
 import { useTheme } from '../contexts/ThemeContext'
 import { useToast } from '../contexts/ToastContext'
 import ResultsGrid from '../components/ResultsGrid'
-import { generateImages } from '../services/api'
+import { generateImages, getImageModels } from '../services/api'
 import './Home.css'
 
 const PLATFORM_PRESETS = [
@@ -65,6 +65,20 @@ function Home() {
   const [showHistory, setShowHistory] = useState(false)
   const [templates, setTemplates] = useState(loadTemplates)
   const [showSaveTemplate, setShowSaveTemplate] = useState(false)
+  const [models, setModels] = useState([])
+  const [model, setModel] = useState('dall-e-3')
+
+  useEffect(() => {
+    let cancelled = false
+    getImageModels()
+      .then((res) => {
+        if (cancelled || !res?.models) return
+        setModels(res.models)
+        if (res.default) setModel(res.default)
+      })
+      .catch(() => { /* fall back to default; UI still usable */ })
+    return () => { cancelled = true }
+  }, [])
 
   const toggle = (id) => {
     setSelected(prev => prev.includes(id) ? prev.filter(x => x !== id) : [...prev, id])
@@ -74,7 +88,7 @@ function Home() {
     if (!prompt.trim() || selected.length === 0) return
     setIsGenerating(true)
     try {
-      const response = await generateImages({ prompt: prompt.trim(), presets: selected })
+      const response = await generateImages({ prompt: prompt.trim(), presets: selected, model })
       const images = response.images || []
       setResults(images)
       toast.success(`Generated ${images.length} image${images.length > 1 ? 's' : ''}`)
@@ -224,6 +238,21 @@ function Home() {
       <main className="workspace">
         {/* Input Panel */}
         <div className="panel input-panel">
+          <div className="panel-section model-section">
+            <label className="field-label" htmlFor="model-picker">Model</label>
+            <select
+              id="model-picker"
+              className="model-picker"
+              value={model}
+              onChange={e => setModel(e.target.value)}
+              disabled={isGenerating}
+            >
+              {(models.length > 0 ? models : [{ id: model, name: model }]).map(m => (
+                <option key={m.id} value={m.id}>{m.name || m.id}</option>
+              ))}
+            </select>
+          </div>
+
           <div className="panel-section">
             <label className="field-label">Describe your image</label>
             <textarea

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -67,6 +67,7 @@ function Home() {
   const [showSaveTemplate, setShowSaveTemplate] = useState(false)
   const [models, setModels] = useState([])
   const [model, setModel] = useState('dall-e-3')
+  const [augment, setAugment] = useState(true)
 
   useEffect(() => {
     let cancelled = false
@@ -88,7 +89,7 @@ function Home() {
     if (!prompt.trim() || selected.length === 0) return
     setIsGenerating(true)
     try {
-      const response = await generateImages({ prompt: prompt.trim(), presets: selected, model })
+      const response = await generateImages({ prompt: prompt.trim(), presets: selected, model, augment })
       const images = response.images || []
       setResults(images)
       toast.success(`Generated ${images.length} image${images.length > 1 ? 's' : ''}`)
@@ -251,6 +252,16 @@ function Home() {
                 <option key={m.id} value={m.id}>{m.name || m.id}</option>
               ))}
             </select>
+            <label className="augment-toggle">
+              <input
+                type="checkbox"
+                checked={augment}
+                onChange={e => setAugment(e.target.checked)}
+                disabled={isGenerating}
+              />
+              <span>Enhance my prompt automatically</span>
+              <span className="augment-hint" title="Adds quality and composition hints so images crop cleanly to every selected aspect ratio.">?</span>
+            </label>
           </div>
 
           <div className="panel-section">

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -77,7 +77,11 @@ function Home() {
         setModels(res.models)
         if (res.default) setModel(res.default)
       })
-      .catch(() => { /* fall back to default; UI still usable */ })
+      .catch((err) => {
+        // Don't break the UI, but surface the failure so we can debug
+        // CORS / server-down issues instead of silently degrading.
+        console.warn('Could not load image models, falling back to default:', err)
+      })
     return () => { cancelled = true }
   }, [])
 

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -131,11 +131,12 @@ export const projectApi = {
 };
 
 // Image Generation API
-export const generateImages = async ({ prompt, presets, model, quality, style }) => {
+export const generateImages = async ({ prompt, presets, model, quality, style, augment }) => {
   const body = { prompt, presets };
   if (model) body.model = model;
   if (quality) body.quality = quality;
   if (style) body.style = style;
+  if (augment === false) body.augment = false;
   return apiClient.post('/api/generate', body);
 };
 

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -131,8 +131,16 @@ export const projectApi = {
 };
 
 // Image Generation API
-export const generateImages = async ({ prompt, presets }) => {
-  return apiClient.post('/api/generate', { prompt, presets });
+export const generateImages = async ({ prompt, presets, model, quality, style }) => {
+  const body = { prompt, presets };
+  if (model) body.model = model;
+  if (quality) body.quality = quality;
+  if (style) body.style = style;
+  return apiClient.post('/api/generate', body);
+};
+
+export const getImageModels = async () => {
+  return apiClient.get('/api/models');
 };
 
 export default apiClient;


### PR DESCRIPTION
## Summary
- Add `gpt-image-1-mini` to the image model registry alongside `gpt-image-1`, `dall-e-3`, `dall-e-2`. Both GPT image models share an OpenAI API contract (sizes, qualities, output formats, backgrounds), so they're now handled through a shared `GPT_IMAGE_MODELS` set rather than a model-name conditional. Default model switched to `dall-e-3`.
- Add a model picker on the Home page that fetches `/api/models` and sends the chosen model on generate. Picker falls back to the default if the fetch fails (and now logs the error to console).
- Add an opt-out **prompt augmentation** layer (default on) that appends composition + quality hints server-side, so the single base image crops cleanly to every selected aspect ratio. Each result carries the augmented prompt + DALL-E 3's `revised_prompt`, surfaced via a new "Show prompt details" disclosure in the results panel.
- Two infra fixes for `docker compose up` to work cleanly: switch `npm ci --only=production` → `npm install --omit=dev` in `server/Dockerfile` (committed lockfile drifts from package.json — `vitest@^3` was bumped without a lockfile refresh), and pre-create `/usr/src/app/data` so the named `app_data` volume inherits non-root `appuser` ownership instead of EACCES'ing.

## Test plan
- [ ] `GET /api/models` returns all 4 models with `default: 'dall-e-3'`
- [ ] Model dropdown on Home renders all 4 options and persists selection through generate
- [ ] Generate with `augment` on → response carries `augmentedPrompt`; "Show prompt details" reveals both blocks
- [ ] Generate with `augment` off → no `augmentedPrompt` field; only `revisedPrompt` shown (DALL-E 3 only)
- [ ] Generate with `gpt-image-1-mini` selected → succeeds, returns base64 (no URL)
- [ ] `docker compose up -d --build` from a clean checkout starts api + worker + redis + frontend without EACCES on the data volume
- [ ] `docker compose down -v && docker compose up -d --build` repeats cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)